### PR TITLE
renamed apk GCam to Gcam to match apk file name

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1,7 +1,7 @@
 android_app_import {
 	name: "GCam",
 	owner: "google",
-	apk: "GCam.apk",
+	apk: "Gcam.apk",
 	presigned: true,
 	dex_preopt: {
 		enabled: false,


### PR DESCRIPTION
The apk field had "G**C**am" while the apk file itself is "G**c**am" with small c.